### PR TITLE
Mejoras para las fechas de los reportes, mejores tooltips para los gráficos y fechas automaticas para los periodos del widget de "Rework Historico"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # scisa-benchmark-frontend
 
+
+## 0.2.0 - 05-08-2025
+
+### Resumen
+Se agrega información de los reportes del rework-rate dentro la grafica de "Rework Historico" en el tablero, al mismo tiempo se agrega mejor formato para las fechas de los mismos reportes, los tooltips de los reportes se posicionan dependiendo de la pantalla para no cubrir puntos importantes en el tablero. Las fechas del widget del "Rework Historico" tienen por defecto el último periodo de reportes.
+
+### Fixed
+
+### Added
+    - [221] Se agrega información de los reportes del rework-rate dentro la grafica de "Rework Historico" en el tablero
+    - [219] Las fechas del widget del "Rework Historico" tienen por defecto el último periodo de reportes.
+
+### Changed
+    - [221] Los reportes dentro del Chart de "Rework Historico" contiene más información.
+    
+### Deprecated
+
+### Removed
+
+### Security
+
+
 ## 0.1.2 - 05-07-2025
 
 ### Resumen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scisa-benchmark-frontend",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/@core/date/dateHelpers.ts
+++ b/src/@core/date/dateHelpers.ts
@@ -132,3 +132,22 @@ export const dateRangeToRange = ({ start, end }: DateRange): DateRangeSchema => 
     end: end ? dateValueToIso(end) : '',
   }
 }
+
+/**
+ * Convert date.toIsoString() to DD/MM/YYYY
+ * @param isoString String from date.toIsoString()
+ * @returns String in format DD/MM/YYYY
+ * @example ```ts
+ * const date = isoToDateValue(new Date().toISOString())
+ * console.log(result) // String in format DD/MM/YYYY
+ * ```
+ **/
+
+export const isoStringToMask = (isoString: string): string => {
+  // To ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ to DD/MM/YYYY
+  const date = new Date(isoString)
+  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0') // Months are zero-based
+  const year = String(date.getFullYear())
+  return `${day}/${month}/${year}`
+}

--- a/src/components/charts/lineCharts/LineChart.vue
+++ b/src/components/charts/lineCharts/LineChart.vue
@@ -17,7 +17,6 @@ import {
   LinearScale,
 } from 'chart.js'
 import type { ChartData, ChartOptions } from 'chart.js'
-import type { ChartDataRework } from '@/types/benchmarks/rework-rate'
 
 // Registrar componentes de Chart.js
 ChartJS.register(Title, Tooltip, Legend, LineElement, PointElement, CategoryScale, LinearScale)
@@ -29,30 +28,88 @@ interface LineChartProps {
 }
 const props = defineProps<LineChartProps>()
 
+
+const externalTooltipHandler = (context: any) => {
+  const { chart, tooltip } = context;
+  const tooltipEl = getOrCreateTooltip(chart);
+
+  if (tooltip.opacity === 0) {
+    tooltipEl.style.opacity = '0';
+    return;
+  }
+
+  const index = tooltip.dataPoints?.[0]?.dataIndex;
+  const dataset = tooltip.dataPoints?.[0]?.dataset;
+
+  if (!dataset || index === undefined) return;
+
+  // Limpiar contenido anterior
+  tooltipEl.innerHTML = '';
+
+  // Título
+  const title = document.createElement('div');
+  title.textContent = tooltip.title?.[0] || '';
+  title.className = 'text-sm font-semibold text-white mb-2';
+
+  // Lista de información
+  const list = document.createElement('ul');
+  list.className = 'space-y-1 text-xs text-white';
+
+  const items = [
+    [`Commits`, dataset.commits?.[index]],
+    [`Autores`, dataset.authors?.[index]],
+    [`PRs`, dataset.prNumbers?.[index]],
+    [`Rework Lines`, dataset.reworkLines?.[index]],
+    [`Periodo`, `${dataset.periodsStart?.[index]} - ${dataset.periodsEnd?.[index]}`],
+    [`Fecha`, dataset.timestamps?.[index]],
+  ];
+
+  items.forEach(([label, value]) => {
+    const li = document.createElement('li');
+    li.textContent = `${label}: ${value ?? '-'}`;
+    list.appendChild(li);
+  });
+
+  tooltipEl.appendChild(title);
+  tooltipEl.appendChild(list);
+
+  // Posición
+  const { offsetLeft: posX, offsetTop: posY } = chart.canvas;
+  tooltipEl.style.opacity = '1';
+  tooltipEl.style.left = `${posX + tooltip.caretX}px`;
+  tooltipEl.style.top = `${posY + tooltip.caretY}px`;
+};
+
+
+function getOrCreateTooltip(chart: any) {
+  let tooltipEl = chart.canvas.parentNode.querySelector('.external-tooltip');
+
+  if (!tooltipEl) {
+    tooltipEl = document.createElement('div');
+    tooltipEl.className =
+      'external-tooltip z-[9999] absolute min-w-[300px] bg-black/80 text-white text-xs rounded-lg shadow-lg p-3 pointer-events-none transform -translate-x-1/2 transition-all z-50';
+    chart.canvas.parentNode.appendChild(tooltipEl);
+  }
+
+  return tooltipEl;
+}
+
+
 // Opciones con tooltip personalizado
 const chartOptions = {
   ...props.options,
   plugins: {
     ...props.options?.plugins,
+    
     tooltip: {
-      callbacks: {
-        // Título del tooltip (por ejemplo, la categoría del eje X)
-        title: (tooltipItems) => {
-          return `${tooltipItems[0].label}`
-        },
-        // Texto principal del tooltip
-        label: (ctx) => {
-          const value = ctx.formattedValue
-          const label = ctx.dataset.label ?? 'Valor'
-          return `Rework: ${value}%`
-        },
-        // Texto adicional después del label
-        afterLabel: (ctx) => {
-          const commitCount = (ctx.dataset as any).commits[ctx.dataIndex];
-          return `Total Commits: ${commitCount}`
-        }
-      }
-    }
-  }
+      enabled: false,
+      position: 'nearest',
+      external: externalTooltipHandler,
+    },
+  },
 } satisfies ChartOptions<'line'>
+
+
+
+
 </script>

--- a/src/components/charts/lineCharts/LineChart.vue
+++ b/src/components/charts/lineCharts/LineChart.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { Chart, Line } from 'vue-chartjs'
+import { Line } from 'vue-chartjs'
 import {
   Chart as ChartJS,
   Title,
@@ -17,6 +17,8 @@ import {
   LinearScale,
 } from 'chart.js'
 import type { ChartData, ChartOptions } from 'chart.js'
+
+import { isoStringToMask } from '@/@core/date/dateHelpers'
 
 // Registrar componentes de Chart.js
 ChartJS.register(Title, Tooltip, Legend, LineElement, PointElement, CategoryScale, LinearScale)
@@ -61,14 +63,15 @@ const externalTooltipHandler = (context: any) => {
   // Lista de información
   const list = document.createElement('ul');
   list.className = 'space-y-1 text-xs text-white';
-
   const items = [
-    [`Commits`, dataset.commits?.[index]],
     [`Autores`, dataset.authors?.[index]],
     [`PRs`, dataset.prNumbers?.[index]],
+    [`Rework Rate`, `${dataset.data?.[index]}%`,],
+    [`Commits`, dataset.commits?.[index]],
     [`Rework Lines`, dataset.reworkLines?.[index]],
-    [`Periodo`, `${dataset.periodsStart?.[index]} - ${dataset.periodsEnd?.[index]}`],
-    [`Fecha`, dataset.timestamps?.[index]],
+    [`Total lines`, dataset.modifiedLines?.[index]],
+    [`Periodo`, `${isoStringToMask(dataset.periodsStart?.[index])} - ${isoStringToMask(dataset.periodsEnd?.[index])}`],
+    [`Fecha`, isoStringToMask(dataset.timestamps?.[index])],
   ];
 
   items.forEach(([label, value]) => {

--- a/src/components/charts/lineCharts/LineChart.vue
+++ b/src/components/charts/lineCharts/LineChart.vue
@@ -29,6 +29,13 @@ interface LineChartProps {
 const props = defineProps<LineChartProps>()
 
 
+const TOOLTIP_STYLES = {
+  base: 'external-tooltip fixed z-[9999] min-w-[300px] bg-black/80 text-white text-xs rounded-lg shadow-lg p-3 pointer-events-none transform transition-all z-50',
+  left: '-translate-x-full',
+  center: '-translate-x-1/2',
+  right: '',
+}
+
 const externalTooltipHandler = (context: any) => {
   const { chart, tooltip } = context;
   const tooltipEl = getOrCreateTooltip(chart);
@@ -78,6 +85,20 @@ const externalTooltipHandler = (context: any) => {
   tooltipEl.style.opacity = '1';
   tooltipEl.style.left = `${posX + tooltip.caretX}px`;
   tooltipEl.style.top = `${posY + tooltip.caretY}px`;
+
+
+  // Ajustar la posición del tooltip dependiendo de su tamaño y la posición del canvas
+  const canvasWidth = chart.canvas.offsetWidth;
+  const caretRatio = tooltip.caretX / canvasWidth;
+
+  let positionClass = TOOLTIP_STYLES.center;
+  if (caretRatio < 0.33) {
+    positionClass = TOOLTIP_STYLES.right;
+  } else if (caretRatio > 0.66) {
+    positionClass = TOOLTIP_STYLES.left;
+  }
+
+  tooltipEl.className = `${TOOLTIP_STYLES.base} ${positionClass}`;
 };
 
 
@@ -86,8 +107,6 @@ function getOrCreateTooltip(chart: any) {
 
   if (!tooltipEl) {
     tooltipEl = document.createElement('div');
-    tooltipEl.className =
-      'external-tooltip z-[9999] absolute min-w-[300px] bg-black/80 text-white text-xs rounded-lg shadow-lg p-3 pointer-events-none transform -translate-x-1/2 transition-all z-50';
     chart.canvas.parentNode.appendChild(tooltipEl);
   }
 

--- a/src/components/features/dashboard/DasboardTable.vue
+++ b/src/components/features/dashboard/DasboardTable.vue
@@ -1,13 +1,11 @@
 <template>
-  <section class="" name="dashboard-table">
+  <section class="w-full" name="dashboard-table">
     <OptionsBar></OptionsBar>
     <WidgetBoard></WidgetBoard> 
-    <!-- <HistoricalWidget></HistoricalWidget> -->
   </section>
 </template>
 
 <script lang="ts" setup>
 import OptionsBar from '@/components/features/dashboard/OptionsBar.vue'
 import WidgetBoard from './widgets/WidgetBoard.vue'
-import HistoricalWidget from './widgets/HistoricalWidget.vue';
 </script>

--- a/src/components/features/dashboard/OptionsBar.vue
+++ b/src/components/features/dashboard/OptionsBar.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="flex flex-row-reverse bg-white p-2 gap-2 mb-4 shadow rounded">
+  <div class="flex flex-row-reverse bg-white p-2 gap-2 mb-4 shadow rounded ">
+    
     <DashButton @click="handlerModifyDashboard" size="md" variant="secondary">
       <span v-if="!stateBoard" class="flex items-center gap-1">
         <vue-feather size="18" type="edit" />

--- a/src/components/features/dashboard/widgets/HistoricalWidget.vue
+++ b/src/components/features/dashboard/widgets/HistoricalWidget.vue
@@ -83,9 +83,13 @@ const dashboardStore = useDashboardStore()
 
 const repos = ref<ReworkRate[]>([])
 
+const today = new Date()
+const lastPeriod = new Date()
+lastPeriod.setDate(today.getDate() - 21)
+
 const dates = ref({
-  start: undefined,
-  end: undefined,
+  start: lastPeriod.toISOString(),
+  end: new Date().toISOString(),
 })
 
 const meanAndMedian = ref({
@@ -117,6 +121,7 @@ const data: Ref<ChartDataRework> = ref({
       reworkLines: [],
       timestamps: [],
       totalCommits: [],
+      modifiedLines: [],
       borderColor: COLORS['primary-800'],
       fill: false,
       cubicInterpolationMode: 'monotone' as const,
@@ -172,13 +177,13 @@ const handlerData = async (value: string) => {
     // pass datapoints and commits to the chart
     data.value.datasets[0].data = values.datapoints
     data.value.datasets[0].commits = values.commits
-    data.value.datasets[0].totalCommits = values.totalCommits
     data.value.datasets[0].reworkLines = values.reworkLines
     data.value.datasets[0].periodsStart = values.periodsStart
     data.value.datasets[0].periodsEnd = values.periodsEnd
     data.value.datasets[0].timestamps = values.timestamps
     data.value.datasets[0].prNumbers = values.prNumbers
-
+    data.value.datasets[0].authors = values.authors
+    data.value.datasets[0].modifiedLines = values.modifiedLines
   } catch {
     console.error('Error fetching repository history')
   } finally {
@@ -218,6 +223,7 @@ const formatDatesForChart = (repos: ReworkRate[]) => {
   const authors: string[] = []
   const totalCommits: number[] = []
   const reworkPercentage: number[] = []
+  const modifiedLines: number[] = []
 
   repos.forEach((repo) => {
     const date = new Date(repo.periodStart)
@@ -237,8 +243,9 @@ const formatDatesForChart = (repos: ReworkRate[]) => {
     authors.push(repo.author)
     totalCommits.push(repo.totalCommits)
     reworkPercentage.push(repo.reworkPercentage)
+    modifiedLines.push(repo.modifiedLines)
   })
-  return { labels, datapoints, commits, periodsStart, periodsEnd, reworkLines, timestamps, prNumbers, authors, totalCommits, reworkPercentage }
+  return { labels, datapoints, commits, periodsStart, periodsEnd, reworkLines, timestamps, prNumbers, authors, totalCommits, reworkPercentage, modifiedLines }
 }
 
 onMounted(async () => {

--- a/src/components/features/dashboard/widgets/HistoricalWidget.vue
+++ b/src/components/features/dashboard/widgets/HistoricalWidget.vue
@@ -110,6 +110,13 @@ const data: Ref<ChartDataRework> = ref({
       label: 'Rework rate en los meses por porcentaje',
       data: [],
       commits: [],
+      authors: [],
+      periodsEnd: [],
+      periodsStart: [],
+      prNumbers: [],
+      reworkLines: [],
+      timestamps: [],
+      totalCommits: [],
       borderColor: COLORS['primary-800'],
       fill: false,
       cubicInterpolationMode: 'monotone' as const,
@@ -165,6 +172,13 @@ const handlerData = async (value: string) => {
     // pass datapoints and commits to the chart
     data.value.datasets[0].data = values.datapoints
     data.value.datasets[0].commits = values.commits
+    data.value.datasets[0].totalCommits = values.totalCommits
+    data.value.datasets[0].reworkLines = values.reworkLines
+    data.value.datasets[0].periodsStart = values.periodsStart
+    data.value.datasets[0].periodsEnd = values.periodsEnd
+    data.value.datasets[0].timestamps = values.timestamps
+    data.value.datasets[0].prNumbers = values.prNumbers
+
   } catch {
     console.error('Error fetching repository history')
   } finally {
@@ -196,6 +210,15 @@ const formatDatesForChart = (repos: ReworkRate[]) => {
   const labels: string[] = []
   const datapoints: number[] = []
   const commits: number[] = []
+  const periodsStart: string[] = []
+  const periodsEnd: string[] = []
+  const reworkLines: number[] = []
+  const timestamps: string[] = []
+  const prNumbers: string[] = []
+  const authors: string[] = []
+  const totalCommits: number[] = []
+  const reworkPercentage: number[] = []
+
   repos.forEach((repo) => {
     const date = new Date(repo.periodStart)
     const month = date.toLocaleString('default', { month: 'long' })
@@ -206,8 +229,16 @@ const formatDatesForChart = (repos: ReworkRate[]) => {
     )
     datapoints.push(repo.reworkPercentage)
     commits.push(repo.totalCommits)
+    periodsStart.push(repo.periodStart)
+    periodsEnd.push(repo.periodEnd)
+    reworkLines.push(repo.reworkLines)
+    timestamps.push(repo.timestamp)
+    prNumbers.push(repo.prNumber)
+    authors.push(repo.author)
+    totalCommits.push(repo.totalCommits)
+    reworkPercentage.push(repo.reworkPercentage)
   })
-  return { labels, datapoints, commits }
+  return { labels, datapoints, commits, periodsStart, periodsEnd, reworkLines, timestamps, prNumbers, authors, totalCommits, reworkPercentage }
 }
 
 onMounted(async () => {

--- a/src/components/features/dashboard/widgets/WidgetBoard.vue
+++ b/src/components/features/dashboard/widgets/WidgetBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <section name="widgets-board" class="z-[9999] w-full max-w-[90%]">
+  <section name="widgets-board" class="z-[9999] w-full ">
     <GridLayout
       v-model:layout="layout"
       :col-num="12"

--- a/src/components/features/dashboard/widgets/WidgetBoard.vue
+++ b/src/components/features/dashboard/widgets/WidgetBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <section name="widgets-board">
+  <section name="widgets-board" class="z-[9999] w-full max-w-[90%]">
     <GridLayout
       v-model:layout="layout"
       :col-num="12"
@@ -59,7 +59,12 @@ const handlerUpdateLayout = (newLayout: Widget[]) => {
   dashboardStore.UPDATE_WIDGETS_TO_LOCAL_STORAGE()
 }
 
+const $container = ref<HTMLElement | null>(null)
+
+
 onMounted(()=> {
+  $container.value = document.querySelector('[name="widgets-board"]') as HTMLElement
+
   const currentLayout = localStorage.getItem('widgets')
   if (currentLayout) {
     layout.value = JSON.parse(currentLayout)

--- a/src/components/navs/lateral/LateralNavbar.vue
+++ b/src/components/navs/lateral/LateralNavbar.vue
@@ -58,7 +58,7 @@ const closeMobileSidebar = () => {
 }
 
 const navClasses = computed(() => {
-  const baseClasses = 'fixed top-0 left-0 h-full bg-gray-800 transition-all z-50'
+  const baseClasses = 'absolute top-0 left-0 h-full bg-gray-800 transition-all z-50'
 
   const mobileClasses = isMobile.value
     ? isMobileOpen.value

--- a/src/services/reworkRate/querys.ts
+++ b/src/services/reworkRate/querys.ts
@@ -16,6 +16,10 @@ export const GET_HISTORY_BY_REPO = `
       periodEnd
       reworkPercentage
       totalCommits
+      timestamp
+      modifiedLines
+      reworkLines
+      prApprover
     }
   }`
 

--- a/src/types/benchmarks/benchmarks.ts
+++ b/src/types/benchmarks/benchmarks.ts
@@ -7,6 +7,6 @@ export interface IdentifyBenchmark {
 
 export interface IdentifyBenchmarkRepo {
     repoUrl: string
-    prNumber: number
+    prNumber: string
     prAproved: number
 }

--- a/src/types/benchmarks/rework-rate.ts
+++ b/src/types/benchmarks/rework-rate.ts
@@ -4,7 +4,7 @@ import type { ChartData, ChartDataset } from 'chart.js'
 export interface ReworkRate extends IdentifyBenchmark, IdentifyBenchmarkRepo {
   reworkPercentage: number
   totalCommits: number
-  modifyLines: number
+  modifiedLines: number
   reworkLines: number
   timestamp: string
   author: string
@@ -20,5 +20,6 @@ export interface ChartDataRework extends ChartData<'line'> {
     totalCommits: number[]
     timestamps: string[]
     reworkLines: number[]
+    modifiedLines: number[]
   })[]
 }

--- a/src/types/benchmarks/rework-rate.ts
+++ b/src/types/benchmarks/rework-rate.ts
@@ -6,8 +6,19 @@ export interface ReworkRate extends IdentifyBenchmark, IdentifyBenchmarkRepo {
   totalCommits: number
   modifyLines: number
   reworkLines: number
+  timestamp: string
+  author: string
 }
 
 export interface ChartDataRework extends ChartData<'line'> {
-  datasets: (ChartDataset<'line'> & { commits: number[] })[]
+  datasets: (ChartDataset<'line'> & {
+    commits: number[]
+    authors: string[]
+    prNumbers: string[]
+    periodsStart: string[]
+    periodsEnd: string[]
+    totalCommits: number[]
+    timestamps: string[]
+    reworkLines: number[]
+  })[]
 }

--- a/src/views/Layouts/DashboardLayout.vue
+++ b/src/views/Layouts/DashboardLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="flex h-screen">
+  <section class="flex h-screen relative">
     <LateralNavbar />
     <div class="p-4 flex-1 overflow-auto bg-victoria-50">
       <SuperiorNavbar />


### PR DESCRIPTION
## 0.2.0 - 05-08-2025

### Resumen
Se agrega información de los reportes del rework-rate dentro la grafica de "Rework Historico" en el tablero, al mismo tiempo se agrega mejor formato para las fechas de los mismos reportes, los tooltips de los reportes se posicionan dependiendo de la pantalla para no cubrir puntos importantes en el tablero. Las fechas del widget del "Rework Historico" tienen por defecto el último periodo de reportes.

### Fixed

### Added
    - [221] Se agrega información de los reportes del rework-rate dentro la grafica de "Rework Historico" en el tablero
    - [219] Las fechas del widget del "Rework Historico" tienen por defecto el último periodo de reportes.

### Changed
    - [221] Los reportes dentro del Chart de "Rework Historico" contiene más información.
    
### Deprecated

### Removed

### Security